### PR TITLE
Fixed instructions for switching between PHP 5.6 and PHP 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,14 @@ Switching between PHP 5.6 and PHP 7.2:
 Switch to PHP 5.6 (default after installation):
 ```
 sudo port select php php56
-sudo /opt/local/bin/apxs -A -e -n php7 mod_php70.so
+sudo /opt/local/bin/apxs -A -e -n php7 mod_php72.so
 sudo /opt/local/bin/apxs -a -e -n php5 mod_php56.so
 acr
 ```
 
 Switch to PHP 7.2:
-```sudo port select php php72
+```
+sudo port select php php72
 sudo /opt/local/bin/apxs -A -e -n php5 mod_php56.so
 sudo /opt/local/bin/apxs -a -e -n php7 mod_php72.so
 acr


### PR DESCRIPTION
I think this fixes the instructions in the README.md file. I copied/pasted the instructions to switch back and forth a couple times, the new commands work on the installation on my computer.